### PR TITLE
Revert "Bump @vue/composition-api from 1.0.0-rc.8 to 1.0.0-rc.9"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@fortawesome/vue-fontawesome": "^2.0.0",
-        "@vue/composition-api": "^1.0.0-rc.9",
+        "@vue/composition-api": "^1.0.0-rc.8",
         "axios": "^0.21.1",
         "buefy": "^0.9.7",
         "vue": "^2.6.12",
@@ -1733,9 +1733,9 @@
       "dev": true
     },
     "node_modules/@vue/composition-api": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.0.0-rc.9.tgz",
-      "integrity": "sha512-U//BqmGRVaPyZbYsPfRlmCKnnFkhRzUBu7cjrWn4PSwQ5Oh+M0KcYIHlupUd+Qmd8KwaiYiuUpJLncl3wFsrdg==",
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.0.0-rc.8.tgz",
+      "integrity": "sha512-9ZW2+2WW7iNywVFeaz9K18DW/aA4MLncz+FiUpjtMUKzHpiN1GtYQ8rRYOhHfGXD2Hmp4tTFjqaTM4WeAbB1ig==",
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -9349,9 +9349,9 @@
       }
     },
     "@vue/composition-api": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.0.0-rc.9.tgz",
-      "integrity": "sha512-U//BqmGRVaPyZbYsPfRlmCKnnFkhRzUBu7cjrWn4PSwQ5Oh+M0KcYIHlupUd+Qmd8KwaiYiuUpJLncl3wFsrdg==",
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.0.0-rc.8.tgz",
+      "integrity": "sha512-9ZW2+2WW7iNywVFeaz9K18DW/aA4MLncz+FiUpjtMUKzHpiN1GtYQ8rRYOhHfGXD2Hmp4tTFjqaTM4WeAbB1ig==",
       "requires": {
         "tslib": "^2.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/vue-fontawesome": "^2.0.0",
-    "@vue/composition-api": "^1.0.0-rc.9",
+    "@vue/composition-api": "^1.0.0-rc.8",
     "axios": "^0.21.1",
     "buefy": "^0.9.7",
     "vue": "^2.6.12",


### PR DESCRIPTION
Reverts koedame/webextension-syncroom-plus#649